### PR TITLE
Update directory depth check during init.

### DIFF
--- a/cmd/stack/init.go
+++ b/cmd/stack/init.go
@@ -28,8 +28,9 @@ func initStack() {
 	}
 
 	xStack := strings.Split(stackPath, string(os.PathSeparator))
-	if len(xStack) < 3 {
-		log.Fatalf("stack path '%s' should have be least 3 levels deep", stackPath)
+	if len(xStack) < 2 {
+		log.Fatalf("stack path '%s' should be least 2 levels deep, below '%s'",
+			stackPath, viper.GetString("stackPrefix"))
 	}
 
 	const configSubs = "azure.subscriptions"


### PR DESCRIPTION
Working with sandbox base stack which is structured a little
differently.
Stack directory only needs to be 2 deep, not 3, as we use the first
directory and the last two, so the first and second last elements can
be the same directory.
Can now initialise stacks that are only 2 directories deep below the
nominated stack prefix, instead of 3.