### PR TITLE
Fix #34.

### DIFF
--- a/cmd/stack/init.go
+++ b/cmd/stack/init.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"strings"
 	"sync"
+	"syscall"
 
 	"github.com/jlucktay/stack/pkg/common"
 	"github.com/spf13/viper"
@@ -141,7 +142,13 @@ func initStack() {
 	go func() {
 		errWait := cmdInit.Wait()
 		if errWait != nil {
-			panic(errWait)
+			if exitErr, ok := errWait.(*exec.ExitError); ok {
+				if status, ok := exitErr.Sys().(syscall.WaitStatus); ok {
+					log.Printf("Exit status: %d", status.ExitStatus())
+				}
+			} else {
+				panic(errWait)
+			}
 		}
 		wg.Wait()
 		close(chOut)


### PR DESCRIPTION
- Fix a case where panic occurs, if 'terraform init' does not exit
cleanly.
- Check the exit status via a type assertion to exec.ExitError.
- If the aforementioned type assertion fails, the panic still occurs.