### PR TITLE
Fix issue #39 with SSH remotes.

### DIFF
--- a/pkg/common/stack.go
+++ b/pkg/common/stack.go
@@ -39,7 +39,8 @@ func validateGitRemotes(needle string) error {
 	found := false
 
 	for _, remote := range strings.Split(string(remotes), "\n") {
-		if strings.Contains(remote, "(fetch)") && strings.Contains(remote, needle) {
+		if strings.Contains(remote, "(fetch)") &&
+			(strings.Contains(remote, needle) || strings.Contains(remote, strings.ReplaceAll(needle, ":", "/"))) {
 			found = true
 			break
 		}


### PR DESCRIPTION
- An inaccurate error was being returned when validating git repos with
SSH remotes.
- Swaps colons for slashes when checking repo remotes against
the configured GitHub org/project.

This will fix #39.