### PR TITLE
Fix broken GoReleaser build

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,7 +3,7 @@ before:
     - go mod download
 
 builds:
-  - main: ./cmd/stack/
+  - main: ./
     flags:
       - -v
     env:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,7 +10,12 @@ builds:
       - CGO_ENABLED=0
 
     ldflags:
-      - -s -w -X github.com/jlucktay/stack/pkg/version.version={{.Version}} -X github.com/jlucktay/stack/pkg/version.commit={{.ShortCommit}} -X github.com/jlucktay/stack/pkg/version.date={{.Date}} -X github.com/jlucktay/stack/pkg/version.builtBy=goreleaser
+      - >
+        -s -w
+        -X github.com/jlucktay/stack/pkg/version.version={{.Version}}
+        -X github.com/jlucktay/stack/pkg/version.commit={{.ShortCommit}}
+        -X github.com/jlucktay/stack/pkg/version.date={{.Date}}
+        -X github.com/jlucktay/stack/pkg/version.builtBy=GoReleaser
 
 archives:
   - replacements:


### PR DESCRIPTION
- Updated main entry point
- Split long `ldflags` string with YAML multiline magic