### PR TITLE
Improve 'issue' subcommand

### DIFF
--- a/pkg/cmd/issue/issue.go
+++ b/pkg/cmd/issue/issue.go
@@ -13,23 +13,36 @@ import (
 func NewCommand() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "issue",
-		Short: "Add/update a GitHub issue for this Terraform stack",
-		Long: `A longer description that spans multiple lines and likely contains examples
-	and usage of using your command. For example:
+		Short: "Add a GitHub issue for this Terraform stack",
+		Long: `Creates an issue in the configured GitHub org/repo using the provided PAT.
 
-	Cobra is a CLI library for Go that empowers applications.
-	This application is a tool to generate the needed files
-	to quickly create a Cobra application.`,
+The 'title' flag for this subcommand is optional.
+
+Example usage:
+$ stack issue --title "My issue title" I found a problem with this stack
+
+The above command would create a new issue in the configured GitHub org/repo
+titled "My issue title" with body text of "I found a problem with this stack".`,
 		Run: func(cmd *cobra.Command, args []string) {
+			title, errTitle := cmd.Flags().GetString("title")
+			if errTitle != nil {
+				panic(errTitle)
+			}
+			if title == "" {
+				title = "New issue"
+			}
+
 			if len(args) == 0 {
 				fmt.Println("No issue text was given!")
 				cmd.UsageString()
 				os.Exit(1)
 			}
 
-			common.CreateIssue(args...)
+			common.CreateIssue(title, args...)
 		},
 	}
+
+	c.Flags().StringP("title", "t", "", "If given, title the issue with this string.")
 
 	return c
 }

--- a/pkg/common/github.go
+++ b/pkg/common/github.go
@@ -1,0 +1,15 @@
+package common
+
+import (
+	"context"
+
+	"github.com/google/go-github/v27/github"
+)
+
+func mustGetCurrentGitHubLogin(c *github.Client) string {
+	u, _, err := c.Users.Get(context.Background(), "")
+	if err != nil {
+		panic(err)
+	}
+	return u.GetLogin()
+}

--- a/pkg/common/issue.go
+++ b/pkg/common/issue.go
@@ -14,14 +14,15 @@ import (
 
 // issue flow:
 // 0. get current stack directory
+// 0.1. get current GitHub username
 // 1. send issue to GitHub with appropriate directory tag
 // 2. print the URL of the newly-created issue
 
-func CreateIssue(text ...string) {
+func CreateIssue(title string, text ...string) {
 	// 0
 	stackPath := mustGetStackPath()
 
-	// 1
+	// set up GitHub auth
 	ctx := context.Background()
 	ts := oauth2.StaticTokenSource(
 		&oauth2.Token{
@@ -31,11 +32,17 @@ func CreateIssue(text ...string) {
 	tc := oauth2.NewClient(ctx, ts)
 	client := github.NewClient(tc)
 
+	// 0.1
+	assignee := mustGetCurrentGitHubLogin(client)
+
+	// 1
 	issueRequest := &github.IssueRequest{
-		Title: github.String(strings.Join(text, " ")),
+		Title: &title,
+		Body:  github.String(strings.Join(text, " ")),
 		Labels: &[]string{
 			stackPath,
 		},
+		Assignee: &assignee,
 	}
 
 	issue, _, errCreate := client.Issues.Create(


### PR DESCRIPTION
Improving the 'issue' subcommand, by:
- adding a optional 'title' flag
- looking up the current GitHub login to set as an assignee