### PR TITLE
Fix for #61 around storage account RG.

### DIFF
--- a/pkg/common/azure.go
+++ b/pkg/common/azure.go
@@ -8,16 +8,28 @@ import (
 
 // mustGetStorageAccountKey retrieves an access key to the Azure Storage Account containing the Terraform state files.
 func mustGetStorageAccountKey() string {
-	sc, errGsc := getStorageClient(viper.GetString("azure.state.subscription"))
+	sub := viper.GetString("azure.state.subscription")
+	if sub == "" {
+		panic("the GUID of the subscription containing the remote state storage account " +
+			"has not been specified in your config file")
+	}
+
+	sc, errGsc := getStorageClient(sub)
 	if errGsc != nil {
 		panic(errGsc)
 	}
 
-	alkr, errLk := sc.ListKeys(
-		context.TODO(),
-		viper.GetString("azure.state.resourceGroup"),
-		viper.GetString("azure.state.storageAccount"),
-	)
+	rg := viper.GetString("azure.state.resourceGroup")
+	if rg == "" {
+		panic("the name of the resource group containing the remote state storage account" +
+			"has not been specified in your config file")
+	}
+	sa := viper.GetString("azure.state.storageAccount")
+	if sa == "" {
+		panic("the name of the remote state storage account has not been specified in your config file")
+	}
+
+	alkr, errLk := sc.ListKeys(context.TODO(), rg, sa)
 	if errLk != nil {
 		panic(errLk)
 	}


### PR DESCRIPTION
- bug fix to check config values before using them to query Azure
storage account
- look at config values to see if they are empty/have been supplied