### PR TITLE
Add more logic checking config values are set.

### DIFF
--- a/pkg/cmd/queue.go
+++ b/pkg/cmd/queue.go
@@ -36,10 +36,16 @@ Stack (plan) URL: https://dev.azure.com/Org/Project/_build/results?buildId=1234`
 				panic(errTarget)
 			}
 
+			defIDKey := fmt.Sprintf("azureDevOps.%sDefID", defType)
+			if !viper.IsSet(defIDKey) {
+				panic("build definition ID (" + defType + ") has not been specified under key '" +
+					defIDKey + "' in your config")
+			}
+
 			common.StackQueue(
 				branch,
 				target,
-				viper.GetUint(fmt.Sprintf("azureDevOps.%sDefID", defType)),
+				viper.GetUint(defIDKey),
 			)
 		},
 	}

--- a/pkg/common/azure.go
+++ b/pkg/common/azure.go
@@ -8,28 +8,30 @@ import (
 
 // mustGetStorageAccountKey retrieves an access key to the Azure Storage Account containing the Terraform state files.
 func mustGetStorageAccountKey() string {
-	sub := viper.GetString("azure.state.subscription")
-	if sub == "" {
+	subKey := "azure.state.subscription"
+	if !viper.IsSet(subKey) {
 		panic("the GUID of the subscription containing the remote state storage account " +
-			"has not been specified in your config file")
+			"has not been specified under '" + subKey + "' in your config")
 	}
 
-	sc, errGsc := getStorageClient(sub)
+	sc, errGsc := getStorageClient(viper.GetString(subKey))
 	if errGsc != nil {
 		panic(errGsc)
 	}
 
-	rg := viper.GetString("azure.state.resourceGroup")
-	if rg == "" {
+	rgKey := "azure.state.resourceGroup"
+	if !viper.IsSet(rgKey) {
 		panic("the name of the resource group containing the remote state storage account" +
-			"has not been specified in your config file")
-	}
-	sa := viper.GetString("azure.state.storageAccount")
-	if sa == "" {
-		panic("the name of the remote state storage account has not been specified in your config file")
+			"has not been specified under '" + rgKey + "' in your config")
 	}
 
-	alkr, errLk := sc.ListKeys(context.TODO(), rg, sa)
+	saKey := "azure.state.storageAccount"
+	if !viper.IsSet(saKey) {
+		panic("the name of the remote state storage account has not been specified under '" +
+			saKey + "' in your config")
+	}
+
+	alkr, errLk := sc.ListKeys(context.TODO(), viper.GetString(rgKey), viper.GetString(saKey))
 	if errLk != nil {
 		panic(errLk)
 	}

--- a/pkg/common/init.go
+++ b/pkg/common/init.go
@@ -12,10 +12,15 @@ import (
 func InitStack() {
 	stackPath := mustGetStackPath()
 
+	spKey := "stackPrefix"
+	if !viper.IsSet(spKey) {
+		panic("the stack path prefix has not been specified under '" + spKey + "' in your config")
+	}
+
 	xStack := strings.Split(stackPath, string(os.PathSeparator))
 	if len(xStack) < 2 {
 		panic(fmt.Sprintf("stack path '%s' should be least 2 levels deep, below '%s'",
-			stackPath, viper.GetString("stackPrefix")))
+			stackPath, viper.GetString(spKey)))
 	}
 
 	const configSubs = "azure.subscriptions"
@@ -25,25 +30,36 @@ func InitStack() {
 		panic(fmt.Sprintf("the subscription key '%s' is not present under '%s' in your config", stackSub, configSubs))
 	}
 
+	kpKey := "azure.state.keyPrefix"
+	if !viper.IsSet(kpKey) {
+		panic("the state key prefix has not been specified under '" + kpKey + "' in your config")
+	}
+
 	stackParent := xStack[len(xStack)-2]
 	stack := xStack[len(xStack)-1]
-	stateKey := fmt.Sprintf("%s.%s.%s", viper.GetString("azure.state.keyPrefix"), stackParent, stack)
+	stateKey := fmt.Sprintf("%s.%s.%s", viper.GetString(kpKey), stackParent, stack)
 
 	// Get access key; enables programmatic access to the storage account
-	saKey := mustGetStorageAccountKey()
+	saAccessKey := mustGetStorageAccountKey()
 
 	// Announce init
+	saConfigKey := "azure.state.storageAccount"
+	if !viper.IsSet(saConfigKey) {
+		panic("the name of the Azure storage account containing Terraform state has not been specified under '" +
+			saConfigKey + "' in your config")
+	}
+
 	fmt.Println("Initialising Terraform with following dynamic values:")
 	fmt.Printf("\tcontainer_name:\t\t%s\n", subs[stackSub]) // Container name matches target sub GUID
 	fmt.Printf("\tkey:\t\t\t%s\n", stateKey)
-	fmt.Printf("\tstorage_account:\t%s\n", viper.GetString("azure.state.storageAccount"))
+	fmt.Printf("\tstorage_account:\t%s\n", viper.GetString(saConfigKey))
 
 	// Run the initialisation
 	cmdInit := exec.Command("terraform", "init",
-		fmt.Sprintf("--backend-config=access_key=%s", saKey),
+		fmt.Sprintf("--backend-config=access_key=%s", saAccessKey),
 		fmt.Sprintf("--backend-config=container_name=%s", subs[stackSub]),
 		fmt.Sprintf("--backend-config=key=%s", stateKey),
-		fmt.Sprintf("--backend-config=storage_account_name=%s", viper.GetString("azure.state.storageAccount")))
+		fmt.Sprintf("--backend-config=storage_account_name=%s", viper.GetString(saConfigKey)))
 
 	run(cmdInit)
 }

--- a/pkg/common/issue.go
+++ b/pkg/common/issue.go
@@ -24,10 +24,15 @@ func CreateIssue(title string) {
 	stackPath := mustGetStackPath()
 
 	// set up GitHub auth
+	ghPATKey := "github.pat"
+	if !viper.IsSet(ghPATKey) {
+		panic("the GitHub personal access token has not been specified under '" + ghPATKey + "' in your config")
+	}
+
 	ctx := context.Background()
 	ts := oauth2.StaticTokenSource(
 		&oauth2.Token{
-			AccessToken: viper.GetString("github.pat"),
+			AccessToken: viper.GetString(ghPATKey),
 		},
 	)
 	tc := oauth2.NewClient(ctx, ts)
@@ -54,12 +59,16 @@ func CreateIssue(title string) {
 		Assignee: &assignee,
 	}
 
-	issue, _, errCreate := client.Issues.Create(
-		ctx,
-		viper.GetString("github.org"),
-		viper.GetString("github.repo"),
-		issueRequest,
-	)
+	ghOrgKey := "github.org"
+	if !viper.IsSet(ghOrgKey) {
+		panic("the GitHub organisation has not been specified under '" + ghOrgKey + "' in your config")
+	}
+	ghRepoKey := "github.repo"
+	if !viper.IsSet(ghRepoKey) {
+		panic("the GitHub repository has not been specified under '" + ghRepoKey + "' in your config")
+	}
+
+	issue, _, errCreate := client.Issues.Create(ctx, viper.GetString(ghOrgKey), viper.GetString(ghRepoKey), issueRequest)
 	if errCreate != nil {
 		panic(errors.Wrap(errCreate, "errCreate!\n"))
 	}

--- a/pkg/common/queue.go
+++ b/pkg/common/queue.go
@@ -58,16 +58,25 @@ func StackQueue(branch, targets string, defID uint) {
 	}
 
 	// 3
+	adoOrgKey := "azureDevOps.org"
+	if !viper.IsSet(adoOrgKey) {
+		panic("the Azure DevOps organisation has not been specified under '" + adoOrgKey + "' in your config")
+	}
+	adoProjectKey := "azureDevOps.project"
+	if !viper.IsSet(adoProjectKey) {
+		panic("the Azure Devops project has not been specified under '" + adoProjectKey + "' in your config")
+	}
+	adoPATKey := "azureDevOps.pat"
+	if !viper.IsSet(adoPATKey) {
+		panic("the Azure DevOps personal access token has not been specified under '" + adoPATKey + "' in your config")
+	}
+
 	apiURL := fmt.Sprintf(
 		"https://dev.azure.com/%s/%s/_apis/build/builds?api-version=5.0",
-		viper.GetString("azureDevOps.org"),
-		viper.GetString("azureDevOps.project"),
+		viper.GetString(adoOrgKey),
+		viper.GetString(adoProjectKey),
 	)
-	apiResult, errAPI := SendBuildRequest(
-		apiURL,
-		viper.GetString("azureDevOps.pat"),
-		payload,
-	)
+	apiResult, errAPI := SendBuildRequest(apiURL, viper.GetString(adoPATKey), payload)
 	if errAPI != nil {
 		panic(errAPI)
 	}

--- a/pkg/common/stack.go
+++ b/pkg/common/stack.go
@@ -31,12 +31,26 @@ func GetStackPath(prefix, remote string) (string, error) {
 }
 
 func mustGetStackPath() string {
+	spKey := "stackPrefix"
+	if !viper.IsSet(spKey) {
+		panic("the stack path prefix has not been specified under '" + spKey + "' in your config")
+	}
+
+	ghOrgKey := "github.org"
+	if !viper.IsSet(ghOrgKey) {
+		panic("the GitHub organisation has not been specified under '" + ghOrgKey + "' in your config")
+	}
+	ghRepoKey := "github.repo"
+	if !viper.IsSet(ghRepoKey) {
+		panic("the GitHub repository has not been specified under '" + ghRepoKey + "' in your config")
+	}
+
 	stackPath, errStackPath := GetStackPath(
-		viper.GetString("stackPrefix"),
+		viper.GetString(spKey),
 		fmt.Sprintf(
 			"github.com/%s/%s",
-			viper.GetString("github.org"),
-			viper.GetString("github.repo"),
+			viper.GetString(ghOrgKey),
+			viper.GetString(ghRepoKey),
 		),
 	)
 	if errStackPath != nil {


### PR DESCRIPTION
- some config keys might not have been specified
- when values are required, we ask Viper to confirm they have been set
based on their key name, before going ahead and using their values