### PR TITLE
CI - update Drone and GoReleaser

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -16,8 +16,8 @@ steps:
     volumes:
       - name: deps
         path: /go
-        commands:
-          - go test -cover -race -v ./...
+    commands:
+      - go test -cover -race -v ./...
 
   # Smoke test
   - name: test-smoke

--- a/.drone.yml
+++ b/.drone.yml
@@ -26,7 +26,7 @@ steps:
       - name: deps
         path: /go
     commands:
-      - go build
+      - CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w"
       - mkdir /smoke
       - mv stack /smoke
       - cd /smoke

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,13 +1,14 @@
 before:
   hooks:
+    - make clean
     - go mod download
 
+# Runs 'go build'
 builds:
   - main: ./
+
     flags:
       - -v
-    env:
-      - CGO_ENABLED=0
 
     ldflags:
       - >
@@ -16,6 +17,18 @@ builds:
         -X 'go.jlucktay.dev/stack/pkg/version.commit={{ .ShortCommit }}'
         -X 'go.jlucktay.dev/stack/pkg/version.date={{ .Date }}'
         -X 'go.jlucktay.dev/stack/pkg/version.builtBy=GoReleaser'
+
+    env:
+      - CGO_ENABLED=0
+
+    # List of combinations of GOOS + GOARCH + GOARM to ignore.
+    ignore:
+      - goos: darwin
+        goarch: 386
+
+    # Set the modified timestamp on the output binary, typically you would do this to ensure a build was reproducible.
+    # Pass empty string to skip modifying the output.
+    mod_timestamp: "{{ .CommitTimestamp }}"
 
 archives:
   - replacements:


### PR DESCRIPTION
- ci(drone): fix unit test command
- ci(drone): align build command with Docker approach
- ci(goreleaser): skip Darwin/386 builds, and set binary timestamp to that of last commit